### PR TITLE
Add AH28 page and talks

### DIFF
--- a/_posts/2017-06-13-1-karim-bogtob-machine-learning-sorcellerie-ou-charlatanisme.md
+++ b/_posts/2017-06-13-1-karim-bogtob-machine-learning-sorcellerie-ou-charlatanisme.md
@@ -1,0 +1,20 @@
+---
+layout: talk
+categories: [ talks, api-hour-28 ]
+
+session_url: /api-hours/api-hour-28.html
+session_name: Clermont'ech API Hour &#35;28
+session_short_name: "&#35;28"
+
+author: Karim Bogtob
+author_url:
+author_image:
+
+slides_url:
+video:
+
+title: "Machine Learning, sorcellerie ou charlatanisme ?"
+---
+
+Est-ce un domaine réservé aux sorciers et grands mages de l'informatique ? Ou est-ce un bricolage sans fondements ? Nous en saurons plus dans cette enquête exclusive où l'on introduira les concepts clés et quelques méthodes courantes.
+

--- a/_posts/2017-06-13-2-loic-bourg-jwt-ou-comment-faciliter-la-gestion-des-utilisateurs.md
+++ b/_posts/2017-06-13-2-loic-bourg-jwt-ou-comment-faciliter-la-gestion-des-utilisateurs.md
@@ -1,0 +1,21 @@
+---
+layout: talk
+categories: [ talks, api-hour-28 ]
+
+session_url: /api-hours/api-hour-28.html
+session_name: Clermont'ech API Hour &#35;28
+session_short_name: "&#35;28"
+
+author: Loic Bourg
+author_url:
+author_image:
+
+slides_url:
+video:
+
+title: "JWT ou comment faciliter la gestion des sessions utilisateurs"
+---
+
+La gestion des sessions est un problème complexe. Dans ce talk, j'expliquerai
+comment les JSON Web Token permettent d'en faciliter certains aspects (SSO, scaling, ...).
+

--- a/_posts/2017-06-13-3-myriam-goude-wtf-le-produit-a-quoi-sert-une-equipe-produit-dans-une-entreprise.md
+++ b/_posts/2017-06-13-3-myriam-goude-wtf-le-produit-a-quoi-sert-une-equipe-produit-dans-une-entreprise.md
@@ -1,0 +1,20 @@
+---
+layout: talk
+categories: [ talks, api-hour-28 ]
+
+session_url: /api-hours/api-hour-28.html
+session_name: Clermont'ech API Hour &#35;28
+session_short_name: "&#35;28"
+
+author: Myriam Goude
+author_url:
+author_image:
+
+slides_url:
+video:
+
+title: "WTF le Produit (*) ? (* : à quoi sert une équipe produit dans une entreprise ?)"
+---
+
+Quel est le rôle d'une équipe produit ? Pourquoi en intégrer une ? Les différentes personnes au sein d'une équipe produit et leurs objectifs ? Présentation du workflow par l'exemple de la création d'un nouveau produit.
+

--- a/_posts/2017-06-13-api-hour-28.md
+++ b/_posts/2017-06-13-api-hour-28.md
@@ -1,0 +1,51 @@
+---
+layout: post
+category: api-hours
+title: Clermont'ech API Hour &#35;28
+---
+
+_Hello!_ Nous sommes heureux de vous retrouver pour un nouvel événement juste
+avant le début des vacances ! Vacances qui signeront l'arrivée du beau temps
+mais pas pour autant de la fin de l'année pour Clermont'ech...
+
+## Concept
+
+Trois conférences courtes (2x10 & 1x25 minutes + 5 minutes de questions par talk)
+pour introduire une technologie, un concept ou un outils et en débattre ensuite
+autour d'un verre.
+
+Les API Hours, comme l'ensemble de nos manifestations, se veulent être [des
+lieux où tout le monde est le bienvenu](/code-of-conduct.html).
+
+
+## Informations pratiques
+
+Cet événement aura lieu le **mercredi 28 juin 2017** à **19h** au **Pôle 22 bis**.  C’est un nouveau lieu
+inter-associatif impasse Bonnabaud, près de Jaude.  L'adresse exacte est : [**22 bis impasse Bonnabaud, 63000 Clermont-Ferrand**](https://goo.gl/maps/KRs8ibVn6nu).
+
+[![](http://maps.googleapis.com/maps/api/staticmap?center=22+Impasse+Bonnabaud%2C+63000+Clermont-Ferrand&size=600x400&sensor=false&markers=color:red%7C45.775138,3.078713)](https://goo.gl/maps/KRs8ibVn6nu)
+
+## Inscription
+
+Cet événement est limité à **50 personnes**.  Pour y assister, vous devez vous
+inscrire sur la page Eventbrite de cette session: [https://clermontech-apihour-28.eventbrite.fr](https://clermontech-apihour-28.eventbrite.fr)
+Ouverture des places le **jeudi 22 juin 2017 à 14h00**.
+
+<iframe src="//eventbrite.fr/tickets-external?eid=35372224275&ref=etckt" frameborder="0" height="500" width="100%" vspace="0" hspace="0" marginheight="5" marginwidth="5" scrolling="auto" allowtransparency="true"></iframe>
+
+
+## Programme
+
+### Karim Bogtob • Machine Learning, sorcellerie ou charlatanisme ? (30 min)
+
+Est-ce un domaine réservé aux sorciers et grands mages de l'informatique ? Ou est-ce un bricolage sans fondements ? Nous en saurons plus dans cette enquête exclusive où l'on introduira les concepts clés et quelques méthodes courantes.
+
+### Loic Bourg • JWT ou comment faciliter la gestion des sessions utilisateurs
+
+La gestion des sessions est un problème complexe. Dans ce talk, j'expliquerai
+comment les JSON Web Token permettent d'en faciliter certains aspects (SSO, scaling, ...).
+
+### Myriam Goude • WTF le Produit (\*) ? (\* : à quoi sert une équipe produit dans une entreprise ?)
+
+Quel est le rôle d'une équipe produit ? Pourquoi en intégrer une ? Les différentes personnes au sein d'une équipe produit et leurs objectifs ? Présentation du workflow par l'exemple de la création d'un nouveau produit.
+


### PR DESCRIPTION
In this commit, I added the API Hour #28 page. I also created the related event on Eventbrite and generated the map. I also prepared the talks pages.
